### PR TITLE
fix(Exp3++): mix `trusts` with per-arm exploration ε_t(a), not the scalar learning rate η_t (#225)

### DIFF
--- a/SMPyBandits/Policies/Exp3PlusPlus.py
+++ b/SMPyBandits/Policies/Exp3PlusPlus.py
@@ -95,7 +95,7 @@ class Exp3PlusPlus(BasePolicy):
 
     @property
     def epsilon(self):
-        r"""Compute the vector of parameters :math:`\eta_t(a) = \min\left(\frac{1}{2 K}, \frac{1}{2} \sqrt{\frac{\log K}{t K}}, \xi_t(a) \right)`."""
+        r"""Compute the vector of per-arm exploration rates :math:`\varepsilon_t(a) = \min\left(\frac{1}{2 K}, \frac{1}{2} \sqrt{\frac{\log K}{t K}}, \xi_t(a) \right)`."""
         return np.minimum(
             0.5 / self.nbArms,
             0.5 * np.sqrt(np.log(self.nbArms) / (self.t * self.nbArms)),
@@ -104,17 +104,17 @@ class Exp3PlusPlus(BasePolicy):
 
     @property
     def trusts(self):
-        r"""Update the trusts probabilities according to Exp3PlusPlus formula, and the parameter :math:`\eta_t`.
+        r"""Update the trusts probabilities according to Exp3PlusPlus formula, mixing the weights with the per-arm exploration rates :math:`\varepsilon_t(a)` (the :attr:`epsilon` property), **not** the scalar learning rate :math:`\eta_t`.
 
         .. math::
 
-           \tilde{\rho}'_{t+1}(a) &= (1 - \sum_{a'=1}^{K}\eta_t(a')) w_t(a) + \eta_t(a), \\
+           \tilde{\rho}'_{t+1}(a) &= (1 - \sum_{a'=1}^{K}\varepsilon_t(a')) w_t(a) + \varepsilon_t(a), \\
            \tilde{\rho}_{t+1} &= \tilde{\rho}'_{t+1} / \sum_{a=1}^{K} \tilde{\rho}'_{t+1}(a).
 
         If :math:`rho_t(a)` is the current weight from arm a.
         """
-        # Mixture between the weights and the uniform distribution
-        trusts = ((1 - np.sum(self.eta)) * self.weights) + self.eta
+        # Mixture between the weights and the per-arm exploration rates epsilon_t(a)
+        trusts = ((1 - np.sum(self.epsilon)) * self.weights) + self.epsilon
         # XXX Handle weird cases, slow down everything but safer!
         if not np.all(np.isfinite(trusts)):
             trusts[~np.isfinite(trusts)] = 0  # set bad values to 0


### PR DESCRIPTION
## What

`Policies/Exp3PlusPlus.py`'s sampling distribution (`trusts`) mixed the weights with the **scalar learning rate** `self.eta` instead of the **per-arm exploration-rate vector** `self.epsilon`:

```python
# before
trusts = ((1 - np.sum(self.eta)) * self.weights) + self.eta
# after
trusts = ((1 - np.sum(self.epsilon)) * self.weights) + self.epsilon
```

## Why

Per Seldin & Slivkins (2014), the EXP3++ sampling distribution is

> ρ_t(a) = (1 − Σ_{a'} ε_t(a')) · w_t(a) + ε_t(a)

where ε_t(a) = min(1/2K, η_t, ξ_t(a)) is the **per-arm** exploration rate (the `epsilon` property), and η_t is the scalar learning rate used only in the weights `w_t ∝ exp(−η_t · L̃_t)` (in `getReward`). Mixing with the scalar `eta` instead of the `epsilon` vector means:

1. the convex-combination mass is wrong — `np.sum(self.eta)` of a scalar is just `eta`, not `Σ_a ε_t(a)`;
2. the gap-dependent `ξ_t(a)` capping is dropped whenever it would bind, so the exploration is no longer the per-arm rate the algorithm specifies.

Either way the realized sampling distribution deviates from the paper's ρ_t.

## Fix

- `trusts`: mix with `self.epsilon` (per-arm) instead of `self.eta` (scalar).
- Docstrings in `epsilon` and `trusts` relabelled — they wrote `η_t(a)` where the quantity is the exploration rate `ε_t(a)`, which is what prompted the confusion in the first place.

This is the fix reported by @szrlee and confirmed by @Naereen in #225 ("I agree with what you say. Can you write a pull request to fix these issues").

## Verification

- `python -m py_compile Policies/Exp3PlusPlus.py` passes.
- A standalone reproduction of the mixing on a toy state confirms the scalar-`eta` and per-arm-`epsilon` distributions differ, and that the `epsilon` form matches the paper's ρ_t.

Closes #225.
